### PR TITLE
Simplify trace_ray, remove heap mallocs

### DIFF
--- a/pykonal/fields.pyx
+++ b/pykonal/fields.pyx
@@ -417,7 +417,6 @@ cdef class ScalarField3D(Field3D):
         """
 
         cdef cpp_vector[constants.REAL_t]         ray
-        cdef Py_ssize_t n
         cdef constants.REAL_t                     norm, step_size, value, value_1back
         cdef constants.REAL_t[3]                  gg
         cdef constants.REAL_t[:]                  point


### PR DESCRIPTION
First, thanks for a very nice and usable library.

In my effort to understand the `trace_ray` algorithm, I rewrote it a bit to remove explicit heap allocations. In my opinion, the result is a bit simpler, so it might be worthwhile to merge.

Briefly, the ray `std::vector` now stores coordinates rather than pointers to coordinate triples. A `memoryview` is used to alias the active/last point in `ray`.

It is probably a bit faster. I think there is also a slight difference in behaviour in that the endpoint itself is checked for NaN value, whereas before only the first step was checked.