### PR TITLE
PyPi package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include pykonal/*.pyx
+include pykonal/*.pxd
+include pykonal/*.cpp


### PR DESCRIPTION
It looks like this is sufficient to create a pypi-compatible source package.

To build:
```
pip install build
python -m build -o dist
```

To upload to pypi:
```
pip install twine
twine upload dist/pykonal-*.tar.gz
```

Now, the `build` command builds both source package and wheel, which I think is nice because it verifies that the wheel is buildable from the sdist. The wheel cannot (and should not) be uploaded though.

Test
===

Test upload can be done by
```
twine upload --repository testpypi dist/pykonal-*.tar.gz
```
and test install by
```
pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple pykonal
```
