### PR TITLE
Workaround for setuptools having become strict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'Cython>=0.29.14', 'numpy']
+requires = ['setuptools==68.2.2', 'wheel', 'Cython>=0.29.14', 'numpy']
 build-backend = 'setuptools.build_meta'
 
 [project]


### PR DESCRIPTION
Pykonal has suddenly become uninstallable. This is an emergency fix/workaround, the root cause should also be fixed but that can come later..

I didn't bump the version, but I think this should be released/uploaded as a new version to PyPi as soon as possible.

Ref issue #42