### PR TITLE
Fix setuptools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools', 'wheel', 'Cython>=0.29.14', 'numpy']
+requires = ['setuptools==68.2.2', 'wheel', 'Cython>=0.29.14', 'numpy']
 build-backend = 'setuptools.build_meta'
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools==68.2.2', 'wheel', 'Cython>=0.29.14', 'numpy']
+requires = ['setuptools<=68.2.2', 'wheel', 'Cython>=0.29.14', 'numpy']
 build-backend = 'setuptools.build_meta'
 
 [project]


### PR DESCRIPTION
Having a setuptools version >68.2.2 seems to break the `pip install pykonal` command. See https://stackoverflow.com/questions/77523055/missingdynamic-license-defined-outside-of-pyproject-toml-is-ignored for a discussion of the error message. Requiring setuptools<=68.2.2 fixes the problem until the project can be updated to work with newer versions of setuptools.