### PR TITLE
Resolve Issue #36: Fix Windows Compilation Error in heapq.pyx by Specifying dtype

### DIFF
--- a/pykonal/heapq.pyx
+++ b/pykonal/heapq.pyx
@@ -33,7 +33,7 @@ cdef class Heap(object):
     """
     def __init__(self, values):
         self.cy_values     = values
-        self.cy_heap_index = np.full(values.shape, fill_value=-1)
+        self.cy_heap_index = np.full(values.shape, fill_value=-1, dtype=np.intp)
 
 
     @property


### PR DESCRIPTION
### Background
This pull request addresses Issue #36 , which reports an exception on Windows within the `heapq.pyx` module. The error was due to a type mismatch during the initialization of `self.cy_heap_index` using `np.full`, expecting 'Py_ssize_t' but receiving 'long'.

### Investigation and Solution
The root cause was identified as the lack of an explicit `dtype` in the `np.full` function call. To fix this issue, `dtype=np.intp` was added to the function call. `np.intp` is the numpy data type designed to be portable across platforms and matches 'ssize_t' in C, which is compatible with 'Py_ssize_t' in Python's C API. This change ensures the correct type is used, aligning with platform-specific requirements, especially on Windows.

### Changes Made
Modified the initialization of `self.cy_heap_index` in `heapq.pyx` to explicitly set the `dtype` to `np.intp`:

From:

```python
self.cy_heap_index = np.full(values.shape, fill_value=-1)
```
To:

```python
self.cy_heap_index = np.full(values.shape, fill_value=-1, dtype=np.intp)
```

### Conclusion
This fix not only resolves the reported issue but also enhances the codebase's portability and compatibility across different platforms. The explicit specification of dtype=np.intp ensures the heapq.pyx module can be compiled on Windows without encountering the previously reported type mismatch error.

I request a review for this pull request to merge the fix into the main branch, addressing Issue #36 and facilitating broader platform compatibility, Thanks!